### PR TITLE
Add back sst file cache

### DIFF
--- a/cloud/cloud_file_cache.cc
+++ b/cloud/cloud_file_cache.cc
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 Rockset.
+#ifndef ROCKSDB_LITE
+
+#include <cinttypes>
+
+#include "cloud/cloud_file_system_impl.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+// The Value inside every cached entry
+struct Value {
+  std::string path;
+  CloudFileSystemImpl* cfs;
+
+  Value(const std::string& _path, CloudFileSystemImpl* _cfs)
+      : path(_path), cfs(_cfs) {}
+};
+
+// static method to use as a callback from the cache.
+static void DeleteEntry(const Slice& key, void* v) {
+  Value* value = reinterpret_cast<Value*>(v);
+  std::string filename(key.data(), key.size());
+  value->cfs->FileCacheDeleter(filename);
+  delete value;
+}
+
+// These are used to retrieve all the values from the cache.
+// Only used for unit tests.
+static Value* DecodeValue(void* v) {
+  return static_cast<Value*>(reinterpret_cast<Value*>(v));
+}
+
+static std::vector<std::pair<Value*, uint64_t>> callback_state;
+static void callback(void* entry, size_t charge) {
+  callback_state.push_back({DecodeValue(entry), charge});
+}
+static void clear_callback_state() { callback_state.clear(); }
+}  // namespace
+
+//
+// Touch the file so that is the the most-recent LRU item in cache.
+//
+void CloudFileSystemImpl::FileCacheAccess(const std::string& fname) {
+  if (!cloud_fs_options.hasSstFileCache()) {
+    return;
+  }
+  Slice key(fname);
+  Cache::Handle* handle = cloud_fs_options.sst_file_cache->Lookup(key);
+  if (handle) {
+    cloud_fs_options.sst_file_cache->Release(handle);
+  }
+  log(InfoLogLevel::DEBUG_LEVEL, fname, "access");
+}
+
+//
+// Record the file into the cache.
+//
+void CloudFileSystemImpl::FileCacheInsert(const std::string& fname,
+                                          uint64_t filesize) {
+  if (!cloud_fs_options.hasSstFileCache()) {
+    return;
+  }
+
+  // insert into cache, key is the file path.
+  Slice key(fname);
+  cloud_fs_options.sst_file_cache->Insert(key, new Value(fname, this), filesize,
+                                          DeleteEntry);
+  log(InfoLogLevel::INFO_LEVEL, fname, "insert");
+}
+
+//
+// Remove a specific entry from the cache.
+//
+void CloudFileSystemImpl::FileCacheErase(const std::string& fname) {
+  // We erase from the cache even if the cache size is zero. This is needed
+  // to protect against the when the cache size was dynamically reduced to zero
+  // on a running database.
+  if (!cloud_fs_options.sst_file_cache) {
+    return;
+  }
+
+  Slice key(fname);
+  cloud_fs_options.sst_file_cache->Erase(key);
+  log(InfoLogLevel::INFO_LEVEL, fname, "erased");
+}
+
+//
+// When the cache is full, delete files from local store
+//
+void CloudFileSystemImpl::FileCacheDeleter(const std::string& fname) {
+  base_fs_->DeleteFile(fname, IOOptions(), nullptr /*dbg*/);
+  log(InfoLogLevel::INFO_LEVEL, fname, "purged");
+}
+
+//
+// Get total charge in the cache.
+// This is not thread-safe and is used only for unit tests.
+//
+uint64_t CloudFileSystemImpl::FileCacheGetCharge() {
+  clear_callback_state();
+  cloud_fs_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
+  uint64_t total = 0;
+  for (auto& it : callback_state) {
+    total += it.second;
+  }
+  return total;
+}
+
+//
+// Get total number of items in the cache.
+// This is not thread-safe and is used only for unit tests.
+//
+uint64_t CloudFileSystemImpl::FileCacheGetNumItems() {
+  clear_callback_state();
+  cloud_fs_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
+  return callback_state.size();
+}
+
+// Removes all items for the env from the cache.
+// This is not thread-safe.
+void CloudFileSystemImpl::FileCachePurge() {
+  // We erase from the cache even if the cache size is zero. This is needed
+  // to protect against the when the cache size was dynamically reduced to zero
+  // on a running database.
+  if (!cloud_fs_options.sst_file_cache) {
+    return;
+  }
+  // fetch all items from cache
+  clear_callback_state();
+  cloud_fs_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
+  // for all those items that have a matching cfs, remove them from cache.
+  for (auto& it : callback_state) {
+    Value* value = it.first;
+    if (value->cfs == this) {
+      Slice key(value->path);
+      cloud_fs_options.sst_file_cache->Erase(key);
+    }
+  }
+  log(InfoLogLevel::INFO_LEVEL, "ENV-DELETE", "purged");
+}
+
+void CloudFileSystemImpl::log(InfoLogLevel level, const std::string& fname,
+                              const std::string& msg) {
+  uint64_t usage = cloud_fs_options.sst_file_cache->GetUsage();
+  uint64_t capacity = cloud_fs_options.sst_file_cache->GetCapacity();
+  long percent = (capacity > 0 ? (100L * usage / capacity) : 0);
+  Log(level, info_log_,
+      "[%s] FileCache %s %s cache-used %" PRIu64 "/%" PRIu64 "(%ld%%) bytes",
+      Name(), fname.c_str(), msg.c_str(), usage, capacity, percent);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+#endif  // ROCKSDB_LITE

--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -48,6 +48,7 @@ CloudFileSystemImpl::~CloudFileSystemImpl() {
     cloud_fs_options.cloud_log_controller->StopTailingStream();
   }
   StopPurger();
+  FileCachePurge();
   cloud_fs_options.cloud_log_controller.reset();
   cloud_fs_options.storage_provider.reset();
 }

--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -240,9 +240,22 @@ IOStatus CloudFileSystemImpl::NewRandomAccessFile(
 
   const IOOptions io_opts;
   if (sstfile || manifest || identity) {
-    if (cloud_fs_options.keep_local_sst_files || !sstfile) {
+    if (cloud_fs_options.keep_local_sst_files ||
+        cloud_fs_options.hasSstFileCache()  || !sstfile) {
       // Read from local storage and then from cloud storage.
       st = base_fs_->NewRandomAccessFile(fname, file_opts, result, dbg);
+
+      // Found in local storage. Update LRU cache.
+      // There is a loose coupling between the sst_file_cache and the files on
+      // local storage. The sst_file_cache is only used for accounting of sst
+      // files. We do not keep a reference to the LRU cache handle when the sst
+      // file remains open by the db. If the LRU policy causes the file to be
+      // evicted, it will be deleted from local storage, but because the db
+      // already has an open file handle to it, it can continue to occupy local
+      // storage space until the time the db decides to close the sst file.
+      if (sstfile && st.ok()) {
+        FileCacheAccess(fname);
+      }
 
       if (!st.ok() && !base_fs_->FileExists(fname, io_opts, dbg).IsNotFound()) {
         // if status is not OK, but file does exist locally, something is wrong
@@ -255,6 +268,14 @@ IOStatus CloudFileSystemImpl::NewRandomAccessFile(
         if (st.ok()) {
           // we successfully copied the file, try opening it locally now
           st = base_fs_->NewRandomAccessFile(fname, file_opts, result, dbg);
+        }
+        // Update the size of our local sst file cache
+        if (st.ok() && sstfile && cloud_fs_options.hasSstFileCache()) {
+          uint64_t local_size;
+          auto statx = base_fs_->GetFileSize(fname, io_opts, &local_size, dbg);
+          if (statx.ok()) {
+            FileCacheInsert(fname, local_size);
+          }
         }
       }
       // If we are being paranoic, then we validate that our file size is
@@ -736,6 +757,11 @@ IOStatus CloudFileSystemImpl::DeleteFile(const std::string& logical_fname,
     // delete from local, too. Ignore the result, though. The file might not be
     // there locally.
     base_fs_->DeleteFile(fname, io_opts, dbg);
+
+    // remove from sst_file_cache
+    if (sstfile) {
+      FileCacheErase(fname);
+    }
   } else if (logfile && !cloud_fs_options.keep_local_log_files) {
     // read from Log Controller
     st = status_to_io_status(
@@ -1065,6 +1091,12 @@ Status CloudFileSystemImpl::CheckOption(const FileOptions& file_opts) {
   // local
   if (file_opts.use_mmap_reads && !cloud_fs_options.keep_local_sst_files) {
     std::string msg = "Mmap only if keep_local_sst_files is set";
+    return Status::InvalidArgument(msg);
+  }
+  if (cloud_fs_options.hasSstFileCache() &&
+      cloud_fs_options.keep_local_sst_files) {
+    std::string msg =
+        "Only one of sst_file_cache or keep_local_sst_files can be set";
     return Status::InvalidArgument(msg);
   }
   return Status::OK();
@@ -1620,6 +1652,13 @@ IOStatus CloudFileSystemImpl::SanitizeLocalDirectory(
         "[cloud_fs_impl] SanitizeDirectory error inspecting dir %s %s",
         local_name.c_str(), st.ToString().c_str());
     return st;
+  }
+
+  if (cloud_fs_options.hasSstFileCache() &&
+      cloud_fs_options.keep_local_sst_files) {
+    std::string msg =
+        "Only one of sst_file_cache or keep_local_sst_files can be set";
+    return IOStatus::InvalidArgument(msg);
   }
 
   // If there is no destination bucket, then we prefer to suck in all sst files

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -30,6 +30,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
+#include "rocksdb/cache.h"
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
@@ -1923,6 +1924,125 @@ TEST_F(CloudTest, SharedBlockCache) {
   clone_cloud_fs->GetStorageProvider()->EmptyBucket(
       cloud_fs_options_.src_bucket.GetBucketName(),
       cloud_fs_options_.src_bucket.GetObjectPath() + "-clone");
+}
+
+// Verify that sst_file_cache and file_cache cannot be set together
+TEST_F(CloudTest, KeepLocalFilesAndFileCache) {
+  cloud_fs_options_.sst_file_cache = NewLRUCache(1024);  // 1 KB cache
+  cloud_fs_options_.keep_local_sst_files = true;
+  ASSERT_TRUE(checkOpen().IsInvalidArgument());
+}
+
+// Verify that sst_file_cache can be disabled
+TEST_F(CloudTest, FileCacheZero) {
+  cloud_fs_options_.sst_file_cache = NewLRUCache(0);  // zero size
+  OpenDB();
+  auto* cimpl = GetCloudFileSystemImpl();
+  ASSERT_OK(db_->Put(WriteOptions(), "a", "b"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Put(WriteOptions(), "c", "d"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  auto local_files = GetSSTFiles(dbname_);
+  EXPECT_EQ(local_files.size(), 0);
+  EXPECT_EQ(cimpl->FileCacheGetCharge(), 0);
+
+  std::string value;
+  ASSERT_OK(db_->Get(ReadOptions(), "a", &value));
+  ASSERT_TRUE(value.compare("b") == 0);
+  ASSERT_OK(db_->Get(ReadOptions(), "c", &value));
+  ASSERT_TRUE(value.compare("d") == 0);
+  CloseDB();
+}
+
+// Verify that sst_file_cache is very small, so no files are local.
+TEST_F(CloudTest, FileCacheSmall) {
+  cloud_fs_options_.sst_file_cache = NewLRUCache(10);  // Practically zero size
+  OpenDB();
+  auto* cimpl = GetCloudFileSystemImpl();
+  ASSERT_OK(db_->Put(WriteOptions(), "a", "b"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Put(WriteOptions(), "c", "d"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  auto local_files = GetSSTFiles(dbname_);
+  EXPECT_EQ(local_files.size(), 0);
+  EXPECT_EQ(cimpl->FileCacheGetCharge(), 0);
+  CloseDB();
+}
+
+// Relatively large sst_file cache, so all files are local.
+TEST_F(CloudTest, FileCacheLarge) {
+  size_t capacity = 10240L;
+  std::shared_ptr<Cache> cache = NewLRUCache(capacity);
+  cloud_fs_options_.sst_file_cache = cache;
+
+  // generate two sst files.
+  OpenDB();
+  auto* cimpl = GetCloudFileSystemImpl();
+  ASSERT_OK(db_->Put(WriteOptions(), "a", "b"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Put(WriteOptions(), "c", "d"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // check that local sst files exist
+  auto local_files = GetSSTFiles(dbname_);
+  EXPECT_EQ(local_files.size(), 2);
+
+  // check that local sst files have non zero size
+  uint64_t totalFileSize = 0;
+  GetSSTFilesTotalSize(dbname_, &totalFileSize);
+  EXPECT_GT(totalFileSize, 0);
+  EXPECT_GE(capacity, totalFileSize);
+
+  // check that cache has two entries
+  EXPECT_EQ(cimpl->FileCacheGetNumItems(), 2);
+
+  // check that cache charge matches total local sst file size
+  EXPECT_EQ(cimpl->FileCacheGetNumItems(), 2);
+  EXPECT_EQ(cimpl->FileCacheGetCharge(), totalFileSize);
+  CloseDB();
+}
+
+// Cache will have a few files only.
+TEST_F(CloudTest, FileCacheOnDemand) {
+  size_t capacity = 3000;
+  int num_shard_bits = 0; // 1 shard
+  bool strict_capacity_limit = false;
+  double high_pri_pool_ratio = 0;
+
+  std::shared_ptr<Cache> cache =
+      NewLRUCache(capacity, num_shard_bits, strict_capacity_limit,
+                  high_pri_pool_ratio, nullptr, kDefaultToAdaptiveMutex,
+                  CacheMetadataChargePolicy::kDontChargeCacheMetadata);
+  cloud_fs_options_.sst_file_cache = cache;
+  options_.level0_file_num_compaction_trigger = 100;  // never compact
+
+  OpenDB();
+  auto* cimpl = GetCloudFileSystemImpl();
+
+  // generate four sst files, each of size about 884 bytes
+  ASSERT_OK(db_->Put(WriteOptions(), "a", "b"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Put(WriteOptions(), "c", "d"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Put(WriteOptions(), "e", "f"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Put(WriteOptions(), "g", "h"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  // The db should have 4 sst files in the manifest.
+  std::vector<LiveFileMetaData> flist;
+  db_->GetLiveFilesMetaData(&flist);
+  EXPECT_EQ(flist.size(), 4);
+
+  // verify that there are only two entries in the cache
+  EXPECT_EQ(cimpl->FileCacheGetNumItems(), 2);
+  EXPECT_EQ(cimpl->FileCacheGetCharge(), cache->GetUsage());
+
+  // There should be only two local sst files.
+  auto local_files = GetSSTFiles(dbname_);
+  EXPECT_EQ(local_files.size(), 2);
+
+  CloseDB();
 }
 
 TEST_F(CloudTest, FindLiveFilesFetchManifestTest) {

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -509,6 +509,10 @@ class CloudFileSystemOptions {
                    const std::string& opts_str);
   Status Serialize(const ConfigOptions& config_options,
                    std::string* result) const;
+  // Is the sst file cache configured?
+  bool hasSstFileCache() const {
+    return sst_file_cache != nullptr && sst_file_cache->GetCapacity() > 0;
+  }
 };
 
 struct CheckpointToCloudOptions {

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -238,6 +238,20 @@ class CloudFileSystemOptions {
   // Default:  null
   std::shared_ptr<CloudStorageProvider> storage_provider;
 
+  // Specifies the amount of sst files to be cached in local storage.
+  // If non-null, then the local storage would be used as a file cache.
+  // The Get or a Scan request on the database generates a random read
+  // request on the sst file and such a request causes the sst file to
+  // be inserted into the local file cache.
+  // A compaction request generates a sequential read request on the sst
+  // file and it does not cause the sst file to be inserted into the
+  // local file cache.
+  // A memtable flush generates a write requst to a new sst file and this
+  // sst file is not inserted into the local file cache.
+  // Cannot be set if keep_local_log_files is true.
+  // Default: null (disabled)
+  std::shared_ptr<Cache>* sst_file_cache;
+
   // Access credentials
   AwsCloudAccessCredentials credentials;
 

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "rocksdb/cache.h"
+#include "rocksdb/advanced_cache.h"
 #include "rocksdb/configurable.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/io_status.h"
@@ -250,7 +250,7 @@ class CloudFileSystemOptions {
   // sst file is not inserted into the local file cache.
   // Cannot be set if keep_local_log_files is true.
   // Default: null (disabled)
-  std::shared_ptr<Cache>* sst_file_cache;
+  std::shared_ptr<Cache> sst_file_cache;
 
   // Access credentials
   AwsCloudAccessCredentials credentials;

--- a/include/rocksdb/cloud/cloud_file_system_impl.h
+++ b/include/rocksdb/cloud/cloud_file_system_impl.h
@@ -250,6 +250,12 @@ class CloudFileSystemImpl : public CloudFileSystem {
   Status ValidateOptions(const DBOptions& /*db_opts*/,
                          const ColumnFamilyOptions& /*cf_opts*/) const override;
 
+  void FileCacheDeleter(const std::string& fname);
+  void FileCacheErase(const std::string& fname);
+  void FileCachePurge();
+  uint64_t FileCacheGetCharge();
+  uint64_t FileCacheGetNumItems();
+
   std::string CloudManifestFile(const std::string& dbname) override;
 
   // Apply cloud manifest delta to in-memory cloud manifest. Does not change the
@@ -351,6 +357,10 @@ class CloudFileSystemImpl : public CloudFileSystem {
   IOStatus FetchCloudManifest(const std::string& local_dbname);
 
   IOStatus RollNewEpoch(const std::string& local_dbname);
+
+    // helper methods to access the file cache
+  void FileCacheAccess(const std::string& fname);
+  void FileCacheInsert(const std::string& fname, uint64_t filesize);
 
   // The dbid of the source database that is cloned
   std::string src_dbid_;

--- a/src.mk
+++ b/src.mk
@@ -24,13 +24,13 @@ LIB_SOURCES =                                                   \
   cloud/db_cloud_impl.cc                                        \
   cloud/cloud_file_system.cc                                    \
   cloud/cloud_file_system_impl.cc                               \
-  cloud/cloud_file_cache.cc                                     \
   cloud/cloud_log_controller.cc                                 \
   cloud/manifest_reader.cc                                      \
   cloud/purge.cc                                                \
   cloud/cloud_manifest.cc                                       \
   cloud/cloud_scheduler.cc                                      \
   cloud/cloud_storage_provider.cc                               \
+  cloud/cloud_file_cache.cc                                     \
   cloud/cloud_file_deletion_scheduler.cc                        \
   db/arena_wrapped_db_iter.cc                                   \
   db/blob/blob_contents.cc                                      \

--- a/src.mk
+++ b/src.mk
@@ -24,6 +24,7 @@ LIB_SOURCES =                                                   \
   cloud/db_cloud_impl.cc                                        \
   cloud/cloud_file_system.cc                                    \
   cloud/cloud_file_system_impl.cc                               \
+  cloud/cloud_file_cache.cc                                     \
   cloud/cloud_log_controller.cc                                 \
   cloud/manifest_reader.cc                                      \
   cloud/purge.cc                                                \


### PR DESCRIPTION
Since RockSet team removed the CloudFileCache.cc from RocksDB-Cloud in their pr,
bit it is important in our scenario, we need to add it back.