### PR TITLE
Update to Aws ListObjects v2 api

### DIFF
--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -659,6 +659,9 @@ class CloudFileSystem : public FileSystem {
   // returns the options used to create this object
   virtual const CloudFileSystemOptions& GetCloudFileSystemOptions() const = 0;
 
+  // returns the options used to create this object
+  virtual CloudFileSystemOptions& GetMutableCloudFileSystemOptions() = 0;
+
   // The SrcBucketName identifies the cloud storage bucket and
   // GetSrcObjectPath specifies the path inside that bucket
   // where data files reside. The specified bucket is used in

--- a/include/rocksdb/cloud/cloud_file_system_impl.h
+++ b/include/rocksdb/cloud/cloud_file_system_impl.h
@@ -401,6 +401,10 @@ class CloudFileSystemImpl : public CloudFileSystem {
     return cloud_fs_options;
   }
 
+  CloudFileSystemOptions& GetMutableCloudFileSystemOptions() override {
+    return cloud_fs_options;
+  }
+
   const std::string& GetSrcBucketName() const override {
     return cloud_fs_options.src_bucket.GetBucketName();
   }


### PR DESCRIPTION
1. The Aws ListObjects() API is slow, which cost 100ms~200ms, vs the Aws ListObjectsV2() API cost below 50ms, so I replace the v1 API with the v2 API.
2. The S3StorageProvider::ListCloudObjects() API will return all objects under a path, but we only need the objects which has name start with CLOUDMANIFEST-, so I introduce another API of ListCloudObjectsWithPrefix()
3. The CloudFileSystemOption is immutable in the CloudFileSystem, so we have to create another CloudFileSystem after determine the CLOUDMANIFEST term when Open DB, so I introduce mutable CloudFileSystemOption to avoid creating another CloudFileSystem. This can reduce 150ms during Open DB.